### PR TITLE
Made Route constructor protected to enforce the creational static method calls.

### DIFF
--- a/src/bitExpert/Pathfinder/Route.php
+++ b/src/bitExpert/Pathfinder/Route.php
@@ -44,9 +44,9 @@ class Route
      * @param array|string $methods The HTTP methods the route is active (e.g. GET, POST, PUT, ...)
      * @param string|null $path
      * @param mixed|null $target
-     * @param callable[] $matchers
+     * @param callable[] $matchers Array key is the name of the path variable, Array value an array of matchers
      */
-    public function __construct($methods = [], $path = null, $target = null, $matchers = [])
+    protected function __construct($methods = [], $path = null, $target = null, array $matchers = [])
     {
         $this->path = $path;
         $this->target = $target;
@@ -61,10 +61,10 @@ class Route
      * @param array $methods
      * @param string|null $path
      * @param mixed|null $target
-     * @param array $matchers
+     * @param callable[] $matchers Array key is the name of the path variable, Array value an array of matchers
      * @return Route
      */
-    public static function create($methods = [], $path = null, $target = null, $matchers = [])
+    public static function create($methods = [], $path = null, $target = null, array $matchers = [])
     {
         return new static($methods, $path, $target, $matchers);
     }
@@ -74,10 +74,10 @@ class Route
      *
      * @param string|null $path
      * @param mixed|null $target
-     * @param callable|callable[] The matcher or array of matchers for the param
+     * @param callable[] $matchers The matcher or array of matchers for the param
      * @return Route
      */
-    public static function get($path = null, $target = null, $matchers = [])
+    public static function get($path = null, $target = null, array $matchers = [])
     {
         return self::create('GET', $path, $target, $matchers);
     }
@@ -87,10 +87,10 @@ class Route
      *
      * @param string|null $path
      * @param mixed|null $target
-     * @param callable|callable[] The matcher or array of matchers for the param
+     * @param callable[] $matchers The matcher or array of matchers for the param
      * @return Route
      */
-    public static function post($path = null, $target = null, $matchers = [])
+    public static function post($path = null, $target = null, array $matchers = [])
     {
         return self::create('POST', $path, $target, $matchers);
     }
@@ -100,10 +100,10 @@ class Route
      *
      * @param string|null $path
      * @param mixed|null $target
-     * @param callable|callable[] The matcher or array of matchers for the param
+     * @param callable[] $matchers The matcher or array of matchers for the param
      * @return Route
      */
-    public static function put($path = null, $target = null, $matchers = [])
+    public static function put($path = null, $target = null, array $matchers = [])
     {
         return self::create('PUT', $path, $target, $matchers);
     }
@@ -113,10 +113,10 @@ class Route
      *
      * @param string|null $path
      * @param mixed|null $target
-     * @param callable|callable[] The matcher or array of matchers for the param
+     * @param callable[] $matchers The matcher or array of matchers for the param
      * @return Route
      */
-    public static function delete($path = null, $target = null, $matchers = [])
+    public static function delete($path = null, $target = null, array $matchers = [])
     {
         return self::create('DELETE', $path, $target, $matchers);
     }
@@ -126,10 +126,10 @@ class Route
      *
      * @param string|null $path
      * @param mixed|null $target
-     * @param callable|callable[] The matcher or array of matchers for the param
+     * @param callable[] $matchers The matcher or array of matchers for the param
      * @return Route
      */
-    public static function options($path = null, $target = null, $matchers = [])
+    public static function options($path = null, $target = null, array $matchers = [])
     {
         return self::create('OPTIONS', $path, $target, $matchers);
     }
@@ -139,10 +139,10 @@ class Route
      *
      * @param string|null $path
      * @param mixed|null $target
-     * @param callable|callable[] The matcher or array of matchers for the param
+     * @param callable[] $matchers The matcher or array of matchers for the param
      * @return Route
      */
-    public static function patch($path = null, $target = null, $matchers = [])
+    public static function patch($path = null, $target = null, array $matchers = [])
     {
         return self::create('PATCH', $path, $target, $matchers);
     }

--- a/src/bitExpert/Pathfinder/Route.php
+++ b/src/bitExpert/Pathfinder/Route.php
@@ -61,12 +61,11 @@ class Route
      * @param array $methods
      * @param string|null $path
      * @param mixed|null $target
-     * @param callable[] $matchers Array key is the name of the path variable, Array value an array of matchers
      * @return Route
      */
-    public static function create($methods = [], $path = null, $target = null, array $matchers = [])
+    public static function create($methods = [], $path = null, $target = null)
     {
-        return new static($methods, $path, $target, $matchers);
+        return new static($methods, $path, $target);
     }
 
     /**
@@ -74,12 +73,11 @@ class Route
      *
      * @param string|null $path
      * @param mixed|null $target
-     * @param callable[] $matchers The matcher or array of matchers for the param
      * @return Route
      */
-    public static function get($path = null, $target = null, array $matchers = [])
+    public static function get($path = null, $target = null)
     {
-        return self::create('GET', $path, $target, $matchers);
+        return self::create('GET', $path, $target);
     }
 
     /**
@@ -87,12 +85,11 @@ class Route
      *
      * @param string|null $path
      * @param mixed|null $target
-     * @param callable[] $matchers The matcher or array of matchers for the param
      * @return Route
      */
-    public static function post($path = null, $target = null, array $matchers = [])
+    public static function post($path = null, $target = null)
     {
-        return self::create('POST', $path, $target, $matchers);
+        return self::create('POST', $path, $target);
     }
 
     /**
@@ -100,12 +97,11 @@ class Route
      *
      * @param string|null $path
      * @param mixed|null $target
-     * @param callable[] $matchers The matcher or array of matchers for the param
      * @return Route
      */
-    public static function put($path = null, $target = null, array $matchers = [])
+    public static function put($path = null, $target = null)
     {
-        return self::create('PUT', $path, $target, $matchers);
+        return self::create('PUT', $path, $target);
     }
 
     /**
@@ -113,12 +109,11 @@ class Route
      *
      * @param string|null $path
      * @param mixed|null $target
-     * @param callable[] $matchers The matcher or array of matchers for the param
      * @return Route
      */
-    public static function delete($path = null, $target = null, array $matchers = [])
+    public static function delete($path = null, $target = null)
     {
-        return self::create('DELETE', $path, $target, $matchers);
+        return self::create('DELETE', $path, $target);
     }
 
     /**
@@ -129,9 +124,9 @@ class Route
      * @param callable[] $matchers The matcher or array of matchers for the param
      * @return Route
      */
-    public static function options($path = null, $target = null, array $matchers = [])
+    public static function options($path = null, $target = null)
     {
-        return self::create('OPTIONS', $path, $target, $matchers);
+        return self::create('OPTIONS', $path, $target);
     }
 
     /**
@@ -139,12 +134,11 @@ class Route
      *
      * @param string|null $path
      * @param mixed|null $target
-     * @param callable[] $matchers The matcher or array of matchers for the param
      * @return Route
      */
-    public static function patch($path = null, $target = null, array $matchers = [])
+    public static function patch($path = null, $target = null)
     {
-        return self::create('PATCH', $path, $target, $matchers);
+        return self::create('PATCH', $path, $target);
     }
 
     /**

--- a/tests/bitExpert/Pathfinder/RouteUnitTest.php
+++ b/tests/bitExpert/Pathfinder/RouteUnitTest.php
@@ -24,7 +24,7 @@ class RouteUnitTest extends \PHPUnit_Framework_TestCase
      */
     public function methodSetByConstructorGetsReturnedInCapitalLetters()
     {
-        $route = new Route('get');
+        $route = Route::create('get');
         $this->assertSame(['GET'], $route->getMethods());
 
         $route = Route::create('get', '/', 'test');
@@ -54,7 +54,7 @@ class RouteUnitTest extends \PHPUnit_Framework_TestCase
      */
     public function pathSetByConstructorGetsReturnedAsIs()
     {
-        $route = new Route('GET', '/info');
+        $route = Route::create('get', '/info');
         $this->assertSame('/info', $route->getPath());
     }
 
@@ -81,7 +81,7 @@ class RouteUnitTest extends \PHPUnit_Framework_TestCase
      */
     public function targetSetByConstructorGetsReturnedAsIs()
     {
-        $route = new Route('get', '/info', 'test');
+        $route = Route::create('get', '/info', 'test');
         $this->assertSame('test', $route->getTarget());
     }
 

--- a/tests/bitExpert/Pathfinder/RouteUnitTest.php
+++ b/tests/bitExpert/Pathfinder/RouteUnitTest.php
@@ -290,12 +290,8 @@ class RouteUnitTest extends \PHPUnit_Framework_TestCase
 
         $target = 'test';
         $path = '/[:param]';
-        $matchers = [
-            'param' => $this->getMockForAbstractClass(Matcher::class)
-        ];
-
         foreach ($methods as $method) {
-            $this->assertStaticRouteCreationFunction($method, $path, $target, $matchers);
+            $this->assertStaticRouteCreationFunction($method, $path, $target);
         }
     }
 

--- a/tests/bitExpert/Pathfinder/RouteUnitTest.php
+++ b/tests/bitExpert/Pathfinder/RouteUnitTest.php
@@ -229,8 +229,9 @@ class RouteUnitTest extends \PHPUnit_Framework_TestCase
             Route::get('/order/[:orderId]')
                 ->to('my.GetActionTokenWithFunctionMatcher')
                 ->ifMatches('orderId', function ($orderId) {
-                    return ((int)$orderId > 0);
-                });
+                    return ((int) $orderId > 0);
+                }
+                );
         } catch (\Exception $e) {
             $thrown = true;
         }
@@ -267,8 +268,9 @@ class RouteUnitTest extends \PHPUnit_Framework_TestCase
     public function returnsTrueIfTargetIsCallable()
     {
         $route = Route::get('/users')->to(function () {
-           // do nothing
-        });
+            // do nothing
+        }
+        );
 
         $this->assertTrue($route->hasCallableTarget());
     }
@@ -276,23 +278,14 @@ class RouteUnitTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @dataProvider httpMethodDataprovider
      */
-    public function staticCreationFunctionsCreateCorrectRoutes()
+    public function staticCreationFunctionsCreateCorrectRoutes($method)
     {
-        $methods = [
-            'get',
-            'post',
-            'put',
-            'delete',
-            'options',
-            'patch'
-        ];
-
         $target = 'test';
         $path = '/[:param]';
-        foreach ($methods as $method) {
-            $this->assertStaticRouteCreationFunction($method, $path, $target);
-        }
+
+        $this->assertStaticRouteCreationFunction($method, $path, $target);
     }
 
     /**
@@ -312,5 +305,22 @@ class RouteUnitTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($path, $route->getPath());
         $this->assertEquals($target, $route->getTarget());
         $this->assertEquals($matchers, $route->getMatchers());
+    }
+
+    /**
+     * Dataprovider to return the http methods to use in the different testcases.
+     *
+     * @return array
+     */
+    public function httpMethodDataprovider()
+    {
+        return [
+            ['get'],
+            ['post'],
+            ['put'],
+            ['delete'],
+            ['options'],
+            ['patch']
+        ];
     }
 }

--- a/tests/bitExpert/Pathfinder/RouteUnitTest.php
+++ b/tests/bitExpert/Pathfinder/RouteUnitTest.php
@@ -230,8 +230,7 @@ class RouteUnitTest extends \PHPUnit_Framework_TestCase
                 ->to('my.GetActionTokenWithFunctionMatcher')
                 ->ifMatches('orderId', function ($orderId) {
                     return ((int) $orderId > 0);
-                }
-                );
+                });
         } catch (\Exception $e) {
             $thrown = true;
         }
@@ -269,8 +268,7 @@ class RouteUnitTest extends \PHPUnit_Framework_TestCase
     {
         $route = Route::get('/users')->to(function () {
             // do nothing
-        }
-        );
+        });
 
         $this->assertTrue($route->hasCallableTarget());
     }

--- a/tests/bitExpert/Pathfinder/RoutingResultUnitTest.php
+++ b/tests/bitExpert/Pathfinder/RoutingResultUnitTest.php
@@ -64,7 +64,7 @@ class RoutingResultUnitTest extends \PHPUnit_Framework_TestCase
      */
     public function forFailureGeneratesValidResultWithRoute()
     {
-        $route = $this->getMock(Route::class);
+        $route = $this->getMock(Route::class, [], [], '', false);
         $result = RoutingResult::forFailure(RoutingResult::FAILED_BAD_REQUEST, $route);
 
         $this->assertTrue($result->failed());


### PR DESCRIPTION
Also corrected docblock comments as well as the method parameter type hints.

Reason for this change is to make it clearer how to construct a route object. Especially the $matchers parameter of the constructor is not really good because one needs to know how the array needs to be constructed. 

To discuss: I would love to get rid of the $matchers parameter for the creational methods (e.g. get(), post()...) for the very same reason. Since the array is used internally as it was given one does need to know the exact structure of the array upfront. We do already have the ifMatches() method so be able to set a matcher individually. I think this is enough we need to offer.
