### PR TITLE
Remove VersionEye badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 A PHP routing component.
 
 [![Build Status](https://travis-ci.org/bitExpert/pathfinder.svg?branch=master)](https://travis-ci.org/bitExpert/pathfinder)
-[![Dependency Status](https://www.versioneye.com/user/projects/57d9b2a97129660042d111c6/badge.svg?style=flat-square)](https://www.versioneye.com/user/projects/57d9b2a97129660042d111c6)
 [![Coverage Status](https://coveralls.io/repos/github/bitExpert/pathfinder/badge.svg?branch=master)](https://coveralls.io/github/bitExpert/pathfinder?branch=master)
 
 Router


### PR DESCRIPTION
Remove the VersionEye badge from the readme file due to versioneye shutting down end of 2017.

More information about the VersionEye sunset process:
https://blog.versioneye.com/2017/10/19/versioneye-sunset-process/
